### PR TITLE
Fixes double evaluation of result in Cache Support

### DIFF
--- a/cache/src/main/scala/org/scalatra/cache/CacheSupport.scala
+++ b/cache/src/main/scala/org/scalatra/cache/CacheSupport.scala
@@ -35,7 +35,7 @@ trait CacheSupport { self: ScalatraBase =>
       case None =>
         val res = result
         val rev = headerStrategy.getNewRevision()
-        cacheBackend.put(key, (rev, result), ttl)
+        cacheBackend.put(key, (rev, res), ttl)
         headerStrategy.setRevision(rev)
         res
     }


### PR DESCRIPTION
This prevents `result` from being evaluated twice by `CacheSupport`.
